### PR TITLE
get app settings from AppDomain BaseDirectory instead of the working directory

### DIFF
--- a/Src/ServiceBusRelayUtilNetCore/Program.cs
+++ b/Src/ServiceBusRelayUtilNetCore/Program.cs
@@ -25,7 +25,7 @@ namespace GaboG.ServiceBusRelayUtilNetCore
         public static void Main(string[] args)
         {
             var builder = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
                 .AddJsonFile("appsettings.json", true, true)
                 .AddEnvironmentVariables();
             Configuration = builder.Build();


### PR DESCRIPTION
in the .NET Core project, use AppDomain.CurrentDomain.BaseDirectory instead of Directory.GetCurrentDirectory() as described in issue #6 